### PR TITLE
White text in Search Bar input, changed width for search and email list

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,14 +1,9 @@
 /* Emails */
 .Cp {
 	/*box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);*/
-	margin: 10px;
+	margin: auto !important;
 	max-width: 1200px;
-}
-
-@media only screen and (min-width: 1600px) {
-	.Cp {
-		margin-left: 100px !important;
-	}
+	padding: 0 10px;
 }
 
 /* Star email */
@@ -166,6 +161,7 @@ header svg {
 /* Search bar (old, new) */
 header form {
 	background: #5E97F6 !important;
+	max-width: 90% !important;
 }
 
 /* Search bar icon on active input (old, new) */
@@ -176,6 +172,11 @@ header form {
 /* Search bar placeholder (old, new) */
 header form input::placeholder {
 	color: #FFF !important;
+}
+
+/* Search bar input */
+header form input {
+	color: white !important;
 }
 
 /* Add reminder */


### PR DESCRIPTION
<img width="806" alt="Screen Shot 2019-03-22 at 2 31 49 AM" src="https://user-images.githubusercontent.com/5100126/54798370-6198a880-4c50-11e9-8a2e-48da0404a268.png">
<img width="1679" alt="Screen Shot 2019-03-22 at 2 57 36 AM" src="https://user-images.githubusercontent.com/5100126/54798371-6198a880-4c50-11e9-8bbc-72ed22580853.png">

The black text in the search bar input seems out of place, white suits it better in my opinion.

Also, I've changed the margin/width styling for the emails in the inbox list, so they sit in the center of the screen, like Inbox.