### PR TITLE
Hide top toolbar without hiding inside opened email, Hide right toolbar

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -82,7 +82,7 @@ const updateReminders = function () {
 			email.querySelectorAll(".y6,.Zt").forEach(node => node.outerHTML = "");
 			email.querySelectorAll(".pH.a9q").forEach(node => {
 				node.style.opacity = "1";
-				node.style.backgroundImage = "url('https://gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/ic_reminder_blue_24dp_r2.png')";
+				node.style.backgroundImage = "url('https://gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_reminder_blue_24dp_r2_2x.png')";
 			});
 			email.querySelectorAll(".y2").forEach(node => node.style.color = "#202124");
 		}

--- a/src/style.css
+++ b/src/style.css
@@ -94,6 +94,7 @@ td.apU.xY .T-KT.T-KT-Jp::before {
 
 /* behind emails */
 .AO, .Tm.aeJ,
+.nH.bkK.nn,
 
 /* left sidebar */
 .nH.oy8Mbf.nn.aeN,
@@ -237,4 +238,23 @@ header form input {
 .bhZ {
 	position: relative !important;
 	margin-right: -72px;
+}
+
+/* Toolbar above opened email */
+.iH {
+	height: 48px !important;
+	align-items: center;
+}
+
+/* Toolbar above email list */
+.nH.aqK {
+	display: none;
+}
+.D.E.G-atb {
+	height: unset;
+}
+
+/* Right toolbar */
+.bAw {
+	display: none;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -20,20 +20,20 @@ td.apU.xY {
 
 /* Not starred image */
 td.apU.xY .T-KT::before {
-	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_pin_black_24dp.png') !important;
+	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/btw_ic_pin_black_24dp_2x.png') !important;
 	background-size: 24px !important;
 }
 
 /* Starred image */
 td.apU.xY .T-KT.T-KT-Jp::before {
-	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/ic_mark-pinned_clr_24dp_r4.png') !important;
+	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_mark-pinned_clr_24dp_r4_2x.png') !important;
 	background-size: 24px !important;
 	opacity: 1;
 }
 
 /* Starred menu item */
 .aHS-bnw .qj {
-	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_pin_black_24dp.png') !important;
+	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/btw_ic_pin_black_24dp_2x.png') !important;
 	background-size: 24px !important;
 }
 
@@ -77,7 +77,7 @@ td.apU.xY .T-KT.T-KT-Jp::before {
 
 /* Compose email image */
 .z0>.L3::before {
-	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_speeddial_compose_white_24dp.png') !important;
+	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/btw_ic_speeddial_compose_white_24dp_2x.png') !important;
     background-size: 24px !important;
 }
 
@@ -199,7 +199,7 @@ header form input {
 
 /* Add reminder image */
 .add-reminder::before {
-	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_speeddial_reminders_white_24dp.png') !important;
+	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/btw_ic_speeddial_reminders_white_24dp_2x.png') !important;
 	background-size: 24px !important;
 	background-position: center;
     background-repeat: no-repeat;
@@ -216,13 +216,13 @@ header form input {
 
 /* Archive button (inbox email, opened email) */
 .brq, .ar8 {
-	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_done_black_24dp.png') !important;
+	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/btw_ic_done_black_24dp_2x.png') !important;
 	background-size: 24px !important;
 }
 
 /* Snooze button (inbox email, opened email) */
 .brv, .brW {
-	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_snooze_black_24dp.png') !important;
+	background-image: url('https://www.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/btw_ic_snooze_black_24dp_2x.png') !important;
 	background-size: 24px !important;
 }
 


### PR DESCRIPTION
This might be a personal preference thing, let me know what you think.

To return things as close as possible to Inbox, I've gotten rid of the tools on the right, and the toolbar above the email list, while ensuring the toolbar above an opened email still remains visible.