### PR TITLE
[#27] Fix background and border of right side Hangouts panel

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -904,4 +904,12 @@ li.bqX.brv {
 /* Firefox overflow fix right sidebar */
 .brC-aT5-aOt-bsf-Jw, brC-bsf-aT5-aOt {
 	overflow-y: hidden;
+
+/* Right side Hangouts */
+div[aria-label="Hangouts"][role="complementary"] {
+	background-color: rgb(242, 242, 242) !important;
+}
+
+.nH.bkK.nn + .nH.nn {
+	background-color: #e5e5e5 !important;
 }


### PR DESCRIPTION
Solves Issue #27 

When you turn on right side Hangouts in the Advanced settings, it has an ugly blue color making the text unreadable (because it's transparent).

I set the background color of the Hangouts container explicitly to match the same as when it's on the left side. I also fixed the background color of a faux left border, previously also blue, a 1px width vertical line.