### PR TITLE
Fix broken interface elements due to 7a8f570

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -896,15 +896,6 @@ li.bqX.brv {
 	overflow-y: auto;
 }
 
-/* Firefox overflow fix left sidebar */
-.oy8Mbf {
-	overflow-y: hidden;
-}
-
-/* Firefox overflow fix right sidebar */
-.brC-aT5-aOt-bsf-Jw, brC-bsf-aT5-aOt {
-	overflow-y: hidden;
-
 /* Right side Hangouts */
 div[aria-label="Hangouts"][role="complementary"] {
 	background-color: rgb(242, 242, 242) !important;


### PR DESCRIPTION
see #40

Removing these two lines did not appear to break anything in Firefox, can the original necessity of the "FireFox overflow fix" issue be expounded upon?