### PR TITLE
Adding support for multiple inboxes (tabs)

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -226,6 +226,10 @@ const getLabels = function (email) {
 	return Array.from(email.querySelectorAll('.ar .at')).map(el => el.attributes.title.value);
 };
 
+const getTabs = function () {
+	return Array.from(document.querySelectorAll('.aKz')).map(el => el.innerText);
+};
+
 const htmlToElements = function (html) {
 	var template = document.createElement('template');
 	template.innerHTML = html;
@@ -393,7 +397,9 @@ const getEmails = () => {
 	const isInBundleFlag = isInBundle();
 	const processedEmails = [];
 	const allLabels = new Set();
+	const tabs = getTabs();
 
+  let currentTab = tabs.length > 0 ? document.querySelector('.aAy[aria-selected="true"]') : false;
 	let prevTimeStamp = null;
 	labelStats = {};
 
@@ -428,6 +434,16 @@ const getEmails = () => {
 					labelEl.querySelector('.av').innerText = labelEl.innerText.replace(UNBUNDLED_PARENT_LABEL + '/', '');
 				} else {
 					// Hide labels that aren't nested under UNBUNDLED_PARENT_LABEL
+					labelEl.hidden = true;
+				}
+			});
+		}
+		
+		// Check for labels used for Tabs, and hide them from the row.
+		if ( false != currentTab ) {
+			info.emailEl.querySelectorAll('.ar.as').forEach(labelEl => {
+				if ( labelEl.innerText == currentTab.innerText ) {
+					// Remove Tabbed labels from the row.
 					labelEl.hidden = true;
 				}
 			});
@@ -492,6 +508,7 @@ const updateReminders = () => {
 	let lastLabel = null;
 	let isInInboxFlag = isInInbox();
 	let hasImportantMarkers = checkImportantMarkers();
+  let tabs = getTabs();
 
 	cleanupDateLabels();
 	const emailBundles = getBundledLabels();
@@ -572,7 +589,7 @@ const updateReminders = () => {
 				continue;
 			}
 
-			const labels = emailInfo.labels;
+			const labels = emailInfo.labels.filter(x => !tabs.includes(x));
 			if (isInInboxFlag && !emailInfo.isStarred && labels.length && !emailInfo.isUnbundled && !emailInfo.bundleAlreadyProcessed()) {
 				labels.forEach(label => {
 					addClassToEmail(emailEl, BUNDLED_EMAIL_CLASS);

--- a/src/script.js
+++ b/src/script.js
@@ -226,9 +226,7 @@ const getLabels = function (email) {
 	return Array.from(email.querySelectorAll('.ar .at')).map(el => el.attributes.title.value);
 };
 
-const getTabs = function () {
-	return Array.from(document.querySelectorAll('.aKz')).map(el => el.innerText);
-};
+const getTabs = () => Array.from(document.querySelectorAll('.aKz')).map(el => el.innerText);
 
 const htmlToElements = function (html) {
 	var template = document.createElement('template');
@@ -399,7 +397,7 @@ const getEmails = () => {
 	const allLabels = new Set();
 	const tabs = getTabs();
 
-  let currentTab = tabs.length > 0 ? document.querySelector('.aAy[aria-selected="true"]') : false;
+	let currentTab = tabs.length && document.querySelector('.aAy[aria-selected="true"]');
 	let prevTimeStamp = null;
 	labelStats = {};
 
@@ -508,7 +506,7 @@ const updateReminders = () => {
 	let lastLabel = null;
 	let isInInboxFlag = isInInbox();
 	let hasImportantMarkers = checkImportantMarkers();
-  let tabs = getTabs();
+	let tabs = getTabs();
 
 	cleanupDateLabels();
 	const emailBundles = getBundledLabels();


### PR DESCRIPTION
If any of the tabs (social, promotions, updates, and forums) are enabled, this fix will prevent emails for the current tab from being bundled for that label. So basically, no need to disable the tabs anymore ;-)

**Before:**
![before](https://user-images.githubusercontent.com/3408028/58595928-3f1e9f00-8240-11e9-853d-03a753276449.png)

**After:**
![after](https://user-images.githubusercontent.com/3408028/58595994-71300100-8240-11e9-9cb8-58f0193538bc.png)

