### PR TITLE
Fix enabled pinned icon jumping 1 or 2px on hover

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -963,10 +963,10 @@ header form input {
 	display: none;
 }
 .zA .apU.xY .T-KT-JW {
-	display: block;
+	display: flex;
 }
 .aqw .apU.xY .aXw {
-	display: block;
+	display: flex;
 }
 
 /* --------------------------------------------- */


### PR DESCRIPTION
Just a minor CSS edit. Fixes at least part of #67 